### PR TITLE
Add basic support for dart sass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ keywords = ["rocket", "sass", "fairing"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["backend_rsass"]
+# Enable rsass support
+backend_rsass = []
+# Enable dart-sass support (via Command, `sass` must be in the path)
+backend_dart_sass = []
+
 [dependencies]
 rocket = "0.5.0-rc.1"
 rsass = "0.25.2"

--- a/README.md
+++ b/README.md
@@ -64,17 +64,16 @@ You can change the output format of the css files by setting the `format` parame
 #[macro_use]
 extern crate rocket;
 
-use sass_rocket_fairing::{SassFairing, rsass};
+use sass_rocket_fairing::{SassFairing, SassBackend, rsass};
 
 #[launch]
 fn rocket() -> _ {
     rocket::build()
-        .attach(SassFairing::new(rsass::output::Format {
+        .attach(SassFairing::new(SassBackend::RSass(rsass::output::Format {
                 style: output::Style::Compressed,
                 .. Default::default()
-            }
+            }))
         )
-    )
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ impl Fairing for SassFairing {
             }
         };
 
-        if let Some(ctx) = Context::initialize(&sass_path, &css_path, self.backend.clone()) {
+        if let Some(ctx) = Context::initialize(&sass_path, &css_path) {
             Ok(rocket.manage(ContextManager::new(ctx)))
         } else {
             rocket::error!("Sass Initialization failed. Aborting launch.");
@@ -156,7 +156,7 @@ impl Fairing for SassFairing {
         // Precompile sass files if in debug mode
         if cfg!(debug_assertions) {
             rocket::info_!("pre-compiling sass files");
-            ctx_manager.compile_all_and_write();
+            ctx_manager.compile_all_and_write(&self.backend);
         }
     }
 
@@ -169,6 +169,6 @@ impl Fairing for SassFairing {
             .state::<ContextManager>()
             .expect("Sass ContextManager not registered in on_ignite");
 
-        context_manager.reload_if_needed();
+        context_manager.reload_if_needed(&self.backend);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
+#[cfg(not(any(feature = "backend_rsass", feature = "backend_dart_sass")))]
+compile_error!("No sass backend feature enabled. Enable one of `backend_rsass` or `backend_dart_sass`");
+
 mod context;
 
 use rocket::{
     fairing::{Fairing, Info, Kind},
-    log::PaintExt,
     yansi::Paint,
     Build, Orbit, Rocket,
 };
@@ -10,8 +12,8 @@ use rocket::{
 use std::path::PathBuf;
 
 // Re-exports
-// pub use sass_rs;
 pub use context::{Context, ContextManager};
+#[cfg(feature = "backend_rsass")]
 pub use rsass;
 
 const DEFAULT_SASS_DIR: &str = "static/sass";
@@ -19,31 +21,58 @@ const DEFAULT_CSS_DIR: &str = "static/css";
 
 /// Compiles a single sass file and returns the resultant `String`
 /// Using the rsass format specified
-pub fn compile_file(path_buf: PathBuf, format: rsass::output::Format) -> Result<String, String> {
-    match rsass::compile_scss_path(path_buf.as_path(), format) {
-        Ok(res) => Ok(String::from_utf8(res).unwrap()),
-        Err(e) => Err(e.to_string()),
+pub fn compile_file(path_buf: PathBuf, backend: &SassBackend) -> Result<String, String> {
+    match backend {
+        #[cfg(feature = "backend_rsass")]
+        SassBackend::RSass(format) => match rsass::compile_scss_path(path_buf.as_path(), *format) {
+            Ok(res) => Ok(String::from_utf8(res).unwrap()),
+            Err(e) => Err(e.to_string()),
+        },
+        #[cfg(feature = "backend_dart_sass")]
+        SassBackend::DartSass => {
+            use std::process::Command;
+            let out = Command::new("sass")
+                .arg(path_buf)
+                .output()
+                .map_err(|e| e.to_string())?;
+
+            if !out.stderr.is_empty() {
+                rocket::warn_!("Dart Sass stderr: {}", String::from_utf8_lossy(&out.stderr))
+            }
+
+            Ok(String::from_utf8_lossy(&out.stdout).to_string())
+        }
     }
+
+
+}
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum SassBackend {
+    #[cfg(feature = "backend_rsass")]
+    RSass(rsass::output::Format),
+    #[cfg(feature = "backend_dart_sass")]
+    DartSass,
 }
 
 /// Main user facing rocket `Fairing`
 pub struct SassFairing {
-    rsass_format: rsass::output::Format,
+    backend: SassBackend,
 }
 
 impl SassFairing {
-    /// Creates a new `SassFairing` with the specified format
-    pub fn new(format: rsass::output::Format) -> Self {
-        Self {
-            rsass_format: format,
-        }
+    /// Creates a new `SassFairing` with the specified backend configuration
+    pub fn new(backend: SassBackend) -> Self {
+        Self { backend }
     }
 }
 
+#[cfg(feature = "backend_rsass")]
 impl Default for SassFairing {
     fn default() -> Self {
         Self {
-            rsass_format: rsass::output::Format::default(),
+            backend: SassBackend::RSass(rsass::output::Format::default()),
         }
     }
 }
@@ -96,7 +125,7 @@ impl Fairing for SassFairing {
             }
         };
 
-        if let Some(ctx) = Context::initialize(&sass_path, &css_path, self.rsass_format) {
+        if let Some(ctx) = Context::initialize(&sass_path, &css_path, self.backend.clone()) {
             Ok(rocket.manage(ContextManager::new(ctx)))
         } else {
             rocket::error!("Sass Initialization failed. Aborting launch.");
@@ -120,9 +149,9 @@ impl Fairing for SassFairing {
             .strip_prefix(std::env::current_dir().unwrap())
             .expect("css_dir is not defined");
 
-        rocket::info!("{}{}:", Paint::emoji("✨ "), Paint::magenta("Sass"));
-        rocket::info_!("sass directory: {}", Paint::white(sass_dir.display()));
-        rocket::info_!("css directory: {}", Paint::white(css_dir.display()));
+        rocket::info!("✨ {}:", Paint::magenta("Sass"));
+        rocket::info_!("sass directory: {}", Paint::white(&sass_dir.display()));
+        rocket::info_!("css directory: {}", Paint::white(&css_dir.display()));
 
         // Precompile sass files if in debug mode
         if cfg!(debug_assertions) {


### PR DESCRIPTION
I'm using this in a personal project, and it's worked for me so far, though it may have some rough edge-cases. By default, the rsass backend is used, unless a user specifies that they want to use the dart-sass one. I'm open to making any changes you want, this is just the way I implemented it at first glance.